### PR TITLE
Build and push container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,6 @@ jobs:
         cabal v2-update
         cabal v2-build --enable-tests --enable-benchmarks
 
-    - name: Build Image
-      id: build-image
-      uses: redhat-actions/buildah-build@v2
-      with:
-        image: quay.io/wire/ldap-scim-bridge
-        tags: ${{ github.sha }}
-        dockerfiles: |
-          ./Dockerfile
-
     - name: Test
       run: |
         echo 'No tests'
@@ -58,6 +49,15 @@ jobs:
     if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: quay.io/wire/ldap-scim-bridge
+        tags: ${{ github.sha }}
+        dockerfiles: |
+          ./Dockerfile
+
     - name: Push To quay.io
       id: push-to-quay
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -51,7 +51,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
 
     - name: Set output
       id: vars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || (github.event.action == 'created' && startsWith(github.ref, 'refs/tags/v'))
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || (github.event.action == 'create' && startsWith(github.ref, 'refs/tags/v'))
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -46,7 +46,7 @@ jobs:
   publish:
     needs : build
     runs-on: ubuntu-latest
-    if: github.event.action == 'created' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event.action == 'create' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Build Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         echo 'No tests'
 
   publish:
-    needs : build
+    # needs : build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || github.event.action == 'created' && startsWith(github.ref, 'refs/tags/v')
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || (github.event.action == 'created' && startsWith(github.ref, 'refs/tags/v'))
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ steps.build-image.outputs.image }} 
+        tags: ${{ steps.build-image.outputs.tags }}
         registry: quay.io/wire
         username: wire+ldapscimbridge
         password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || github.event.action == 'created' && startsWith(github.ref, 'refs/tags/v')
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -44,8 +44,9 @@ jobs:
         echo 'No tests'
 
   publish:
+    needs : build
     runs-on: ubuntu-latest
-    if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event.action == 'created' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Build Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,32 @@ jobs:
         cabal v2-update
         cabal v2-build --enable-tests --enable-benchmarks
 
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: quay.io/wire/ldap-scim-bridge
+        tags: ${{ github.sha }}
+        dockerfiles: |
+          ./Dockerfile
+
+    - name: Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ github.event.ref }}
+        registry: quay.io/wire
+        username: wire+ldapscimbridge
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      on:
+        push:
+          tags:
+          - '**'
+          
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
     - name: Test
       run: |
         echo 'No tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
   push:
     branches: [master]
+    tags:
+    - 'v*'    
 
 jobs:
   build:
@@ -46,8 +48,18 @@ jobs:
         dockerfiles: |
           ./Dockerfile
 
+    - name: Test
+      run: |
+        echo 'No tests'
+
+  publish:
+    needs: build
+    runs-on: ubuntu-16.04
+    if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
+
     - name: Push To quay.io
       id: push-to-quay
+      
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
@@ -55,14 +67,7 @@ jobs:
         registry: quay.io/wire
         username: wire+ldapscimbridge
         password: ${{ secrets.REGISTRY_PASSWORD }}
-      on:
-        push:
-          tags:
-          - '**'
+
           
     - name: Print image url
       run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
-
-    - name: Test
-      run: |
-        echo 'No tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-16.04
     if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
 
+    steps:
     - name: Push To quay.io
       id: push-to-quay
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
-        image: quay.io/wire/ldap-scim-bridge
+        image: ldap-scim-bridge
         tags: ${{ steps.vars.outputs.tag }}
         dockerfiles: |
           ./Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       id: vars
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
 
-      - name: Build Image
+    - name: Build Image
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         cabal: ["2.4"]
         ghc:
           - "8.8.3"
-    if: '!startsWith(github.ref, 'refs/tags/v')'
+    if: "!startsWith(github.ref, 'refs/tags/v')"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,16 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
 
-    - name: Build Image
+    - name: Set output
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+
+      - name: Build Image
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
         image: quay.io/wire/ldap-scim-bridge
-        tags: ${{ github.sha }}
+        tags: ${{ steps.vars.outputs.tag }}
         dockerfiles: |
           ./Dockerfile
 
@@ -68,7 +72,7 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ github.event.ref }}
+        tags: ${{ steps.build-image.outputs.image }} 
         registry: quay.io/wire
         username: wire+ldapscimbridge
         password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || (github.event.action == 'create' && startsWith(github.ref, 'refs/tags/v'))
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -46,7 +46,7 @@ jobs:
   publish:
     needs : build
     runs-on: ubuntu-latest
-    if: github.event.action == 'create' && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Build Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
         echo 'No tests'
 
   publish:
-    needs: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         cabal: ["2.4"]
         ghc:
           - "8.8.3"
+    if: '!startsWith(github.ref, 'refs/tags/v')'
 
     steps:
     - uses: actions/checkout@v2
@@ -49,6 +50,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
+    - uses: actions/checkout@v2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+
     - name: Build Image
       id: build-image
       uses: redhat-actions/buildah-build@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM haskell:8.8.3-buster
+
+WORKDIR /opt/ldap-scim-bridge
+
+# Add just the .cabal file to capture dependencies
+COPY ./ldap-scim-bridge.cabal /opt/ldap-scim-bridge/ldap-scim-bridge.cabal
+
+RUN cabal v2-update
+
+# Docker will cache this command as a layer, freeing us up to
+# modify source code without re-installing dependencies
+# (unless the .cabal file changes!)
+RUN cabal v2-build --only-dependencies -j4
+
+# Add and Install Application Code
+COPY . /opt/ldap-scim-bridge
+RUN cabal v2-install 
+
+CMD ["ldap-scim-bridge"]


### PR DESCRIPTION
Using git tags to specify the quay container image tag.  For instance will push `v0.1.1` as `quay.io/wire/ldap-scim-bridge:0.1.1`. Runs `build` only on PRs and the master branch and `publish` on tags prefixed with `v`.