### PR TITLE
Filter on arbitrary LDAP attributes

### DIFF
--- a/examples/wire-server/conf1.yaml
+++ b/examples/wire-server/conf1.yaml
@@ -8,6 +8,8 @@ ldapSource:
   search:
     base: "ou=People,dc=nodomain"
     objectClass: "account"
+    #memberOf: "team red"
+    #hairColor: "yellow"
   codec: "utf8"
 scimTarget:
   tls: false

--- a/ldap-scim-bridge.cabal
+++ b/ldap-scim-bridge.cabal
@@ -39,6 +39,7 @@ common common-options
                      , email-validate >=2.3.2.13 && <2.4
                      , string-conversions >=0.4.0.1 && <0.5
                      , servant-client >=0.18.3 && <0.19
+                     , unordered-containers
                      , servant-client-core >=0.18.3 && <0.19
                      , servant >=0.18.3 && <0.19
                      , http-types >=0.12.3 && <0.13

--- a/ldap-scim-bridge.cabal
+++ b/ldap-scim-bridge.cabal
@@ -39,7 +39,7 @@ common common-options
                      , email-validate >=2.3.2.13 && <2.4
                      , string-conversions >=0.4.0.1 && <0.5
                      , servant-client >=0.18.3 && <0.19
-                     , unordered-containers
+                     , unordered-containers >= 0.2.14.0 && <0.3
                      , servant-client-core >=0.18.3 && <0.19
                      , servant >=0.18.3 && <0.19
                      , http-types >=0.12.3 && <0.13

--- a/src/LdapScimBridge.hs
+++ b/src/LdapScimBridge.hs
@@ -126,7 +126,7 @@ instance Aeson.FromJSON LdapSearch where
           go (key, val) = do
             str <- Aeson.withText "val" pure val
             pure $ LdapFilterAttr key str
-      go `mapM` HM.toList obj
+      go `mapM` HM.toList (HM.filterWithKey (\k _ -> k `notElem` ["base", "objectClass"]) obj)
     pure $ LdapSearch (Dn fbase) fobjectClass extra
 
 data ScimConf = ScimConf
@@ -153,7 +153,7 @@ data BridgeConf = BridgeConf
     mapping :: Mapping,
     logLevel :: Level
   }
-  deriving stock (Generic)
+  deriving stock (Show, Generic)
 
 instance Aeson.FromJSON Level where
   parseJSON "Trace" = pure Trace


### PR DESCRIPTION
allows config files like this one:

```
   search:
     base: "ou=People,dc=nodomain"
     objectClass: "account"
+    memberOf: "team red"
+    homeDirectory: "/home/me"
+    hairColor: "yellow"
   codec: "utf8"
```