### PR TITLE
Work on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,40 @@ see https://github.com/wireapp/ldap-scim-bridge for a sample config.
 See [ldif](./ldif/README.md) for a few sample user records to play with.
 A working example can be found in `./examples/wire-server`.
 
+## use via docker
+
+If you have gotten here as a
+[wire-server](https://github.com/wireapp/wire-server) administrator
+and want to use this to populate your teams, you can use the docker
+image we're building from this repo:
+
+```sh
+docker pull quay.io/wire/ldap-scim-bridge:0.5
+```
+
+You need to create a config file that contains your setup.  If in doubt, you can start with [this example](./examples/wire-server/conf1.yaml), or [this one](./examples/wire-server/conf2.yaml).  Name the file `config.yaml` and place it into `/config-path`.  Let's say you want to work on release 0.5.  (You can check if there is a `:latest`, but at the time of writing this paragraph, we still have to add that.)
+
+```sh
+docker run -it --network=host \
+  --mount type=bind,src=/config-path,target=/mnt \
+  quay.io/wire/ldap-scim-bridge:0.5 \
+  ldap-scim-bridge /mnt/config.yaml
+```
+
+This should work fine for Windows if you make sure the file path under `src` points to the right place.  You may need to you `\` instead of `/`.
+
+The connection to wire is not encrypted.  This tool is made for running inside the trusted network the backend is running in.  If you need to protect this connection you can use an off-the-shelf tls tunnel or vpn solution.
+
+The connection to the LDAP source is TLS-encrypted.  If you need to add trusted certificates to the store in `/etc/ssl/certs/`, you can just mount it:
+
+```sh
+docker run -it --network=host \
+  --mount type=bind,src=/config-path,target=/mnt \
+  --mount type=bind,src=/etc/ssl/certs,target=/etc/ssl/certs \
+  quay.io/wire/ldap-scim-bridge:0.5 \
+  ldap-scim-bridge /mnt/config.yaml
+```
+
 ## future work
 
 See https://github.com/wireapp/ldap-scim-bridge/issues


### PR DESCRIPTION
Fixes #10

Some cleanup, but this is mostly for explaining how this can be easily used via docker.

TODO:

- [x] expose mount point for config file.
- [x] call executable with the path to that config file as first argument.
- [x] test instructions.
- [ ] can we tag the `latest` image on quay.io?  (optional)