### PR TITLE
[WPB-14436] helpful dynamic mapping errors

### DIFF
--- a/ldap-scim-bridge.cabal
+++ b/ldap-scim-bridge.cabal
@@ -60,7 +60,7 @@ common common-options
     -O2 -Wall -Wcompat -Widentities -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wpartial-fields -fwarn-tabs
     -optP-Wno-nonportable-include-path -Wredundant-constraints
-    -fhide-source-paths -Wmissing-export-lists -Wpartial-fields
+    -fhide-source-paths -Wpartial-fields
     -Wmissing-deriving-strategies
 
   default-language:   Haskell2010

--- a/src/LdapScimBridge.hs
+++ b/src/LdapScimBridge.hs
@@ -304,7 +304,8 @@ type User = Scim.User ScimTag
 type StoredUser = ScimClass.StoredUser ScimTag
 
 -- | Note that the `userName` field is mandatory in SCIM, but we gloss over this by setting it
--- to an empty Text here.
+-- to an empty Text here.  See 'RequireUserName', 'ldapToScim' if you wonder whether this is a
+-- good idea.
 emptyScimUser :: User
 emptyScimUser =
   Scim.empty scimSchemas "" Scim.NoUserExtra

--- a/src/LdapScimBridge.hs
+++ b/src/LdapScimBridge.hs
@@ -154,6 +154,7 @@ data BridgeConf = BridgeConf
   }
   deriving stock (Show, Generic)
 
+-- | Work around orphan instances.  Might not be a phantom, but I like the name.  :)
 newtype PhantomParent a = PhantomParent {unPhantomParent :: a}
   deriving stock (Eq, Ord, Bounded, Show, Generic)
 

--- a/src/LdapScimBridge.hs
+++ b/src/LdapScimBridge.hs
@@ -84,7 +84,7 @@ instance Aeson.FromJSON LdapConf where
     fpassword :: String <- obj Aeson..: "password"
     fsearch :: LdapSearch <- obj Aeson..: "search"
     fcodec :: Text <- obj Aeson..: "codec"
-    fdeleteOnAttribute :: Maybe LdapFilterAttr <- obj Aeson..:? "deleteOnAttribute" -- TODO: this can go into 'fdeleteFromDirectory'.
+    fdeleteOnAttribute :: Maybe LdapFilterAttr <- obj Aeson..:? "deleteOnAttribute"
     fdeleteFromDirectory :: Maybe LdapSearch <- obj Aeson..:? "deleteFromDirectory"
 
     let vhost :: Host
@@ -237,7 +237,7 @@ instance Aeson.FromJSON Mapping where
           [val] -> Right $ \usr -> usr {Scim.displayName = Just val}
           bad -> Left $ WrongNumberOfAttrValues ldapFieldName "1" (Prelude.length bad)
 
-      -- Really, not username, but handle.
+      -- Wire user handle (the one with the '@').
       mapUserName :: Text -> FieldMapping
       mapUserName ldapFieldName = FieldMapping "userName" $
         \case
@@ -277,10 +277,10 @@ instance Aeson.FromJSON Mapping where
 
 type LdapResult a = IO (Either LdapError a)
 
-ldapObjectClassFilter :: Text -> Filter -- TODO: inline?
+ldapObjectClassFilter :: Text -> Filter
 ldapObjectClassFilter = (Attr "objectClass" :=) . cs
 
-ldapFilterAttrToFilter :: LdapFilterAttr -> Filter -- TODO: inline?  replace LdapFilterAttr with `Attr` and `:=`?
+ldapFilterAttrToFilter :: LdapFilterAttr -> Filter
 ldapFilterAttrToFilter (LdapFilterAttr key val) = Attr key := cs val
 
 listLdapUsers :: LdapConf -> LdapSearch -> LdapResult [SearchEntry]
@@ -308,7 +308,7 @@ scimSchemas = [Scim.User20]
 
 ldapToScim ::
   forall m.
-  m ~ Either [(SearchEntry, MappingError)] =>
+  (m ~ Either [(SearchEntry, MappingError)]) =>
   BridgeConf ->
   SearchEntry ->
   m (SearchEntry, User)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Data.ByteString (ByteString)
+import Data.Function ((&))
+import Data.Maybe (maybeToList)
 import Data.String.Conversions (cs)
 import Data.Text
 import qualified Data.Yaml as Yaml
@@ -12,8 +14,6 @@ import Web.Scim.Schema.Meta as Scim
 import Web.Scim.Schema.Schema as Scim
 import Web.Scim.Schema.User as Scim
 import Web.Scim.Schema.User.Email as Scim
-import Data.Function ((&))
-import Data.Maybe (maybeToList)
 
 main :: IO ()
 main = hspec $ do
@@ -29,7 +29,7 @@ main = hspec $ do
               & addAttr "uidNumber" userName
               & addAttr "email" email
 
-      let expectedScimUser = mkScimUser displayName userName externalId email Nothing
+      let expectedScimUser = mkExpectedScimUser displayName userName externalId email Nothing
 
       conf <- Yaml.decodeThrow confYaml
       let Right (actualSearchEntry, actualScimUser) = ldapToScim conf searchEntry
@@ -49,7 +49,7 @@ main = hspec $ do
               & addAttr "email" email
               & addAttr "employeeType" role
 
-      let expectedScimUser = mkScimUser displayName userName externalId email (Just role)
+      let expectedScimUser = mkExpectedScimUser displayName userName externalId email (Just role)
 
       conf <- Yaml.decodeThrow confYaml
       let Right (actualSearchEntry, actualScimUser) = ldapToScim conf searchEntry
@@ -62,8 +62,8 @@ searchEntryEmpty = SearchEntry (Dn "") []
 addAttr :: Text -> Text -> SearchEntry -> SearchEntry
 addAttr key value (SearchEntry dn attrs) = SearchEntry dn ((Attr key, [cs value]) : attrs)
 
-mkScimUser :: Text -> Text -> Text -> Text -> Maybe Text -> Scim.User ScimTag
-mkScimUser displayName userName externalId email mRole =
+mkExpectedScimUser :: Text -> Text -> Text -> Text -> Maybe Text -> Scim.User ScimTag
+mkExpectedScimUser displayName userName externalId email mRole =
   Scim.User
     { schemas = [User20],
       userName = userName,

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -56,6 +56,19 @@ main = hspec $ do
       actualSearchEntry `shouldBe` searchEntry
       actualScimUser `shouldBe` expectedScimUser
 
+    it "helpful error message if scim userName (wire handle) field is missing" $ do
+      let displayName = "John Doe"
+      let userName = "jdoe"
+      let externalId = "jdoe@nodomain"
+      let email = "jdoe@nodomain"
+      let searchEntry =
+            searchEntryEmpty
+              & addAttr "displayName" displayName
+              & addAttr "email" email
+
+      conf <- Yaml.decodeThrow confYaml
+      ldapToScim conf searchEntry `shouldBe` Left []
+
 searchEntryEmpty :: SearchEntry
 searchEntryEmpty = SearchEntry (Dn "") []
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -32,7 +32,7 @@ main = hspec $ do
       let expectedScimUser = mkExpectedScimUser displayName userName externalId email Nothing
 
       conf <- Yaml.decodeThrow confYaml
-      let Right (actualSearchEntry, actualScimUser) = ldapToScim conf searchEntry
+      let Right (actualSearchEntry, actualScimUser) = ldapToScim Lenient conf searchEntry
       actualSearchEntry `shouldBe` searchEntry
       actualScimUser `shouldBe` expectedScimUser
 
@@ -52,7 +52,7 @@ main = hspec $ do
       let expectedScimUser = mkExpectedScimUser displayName userName externalId email (Just role)
 
       conf <- Yaml.decodeThrow confYaml
-      let Right (actualSearchEntry, actualScimUser) = ldapToScim conf searchEntry
+      let Right (actualSearchEntry, actualScimUser) = ldapToScim Lenient conf searchEntry
       actualSearchEntry `shouldBe` searchEntry
       actualScimUser `shouldBe` expectedScimUser
 
@@ -67,7 +67,7 @@ main = hspec $ do
               & addAttr "email" email
 
       conf <- Yaml.decodeThrow confYaml
-      ldapToScim conf searchEntry `shouldBe` Left []
+      ldapToScim Strict conf searchEntry `shouldBe` Left [(searchEntry, MissingMandatoryValue "userName")]
 
 searchEntryEmpty :: SearchEntry
 searchEntryEmpty = SearchEntry (Dn "") []


### PR DESCRIPTION
Fix a bug because of which invalid input data (no scim `userName` in a POST payload) triggered an `undefined` instead of showing a helpful error.