### PR TITLE
chore: Fix shellcheck linting issues

### DIFF
--- a/admin/publish.sh
+++ b/admin/publish.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2317
+# SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).
+#
+# FUTUREWORK: Re-enable this check when you start using this script.
 
 echo "WARNING!! this script has never run!!  test carefully!!"
 exit 1
@@ -8,11 +12,11 @@ exit 1
 dir=$(mktemp -d dist-docs.XXXXXX)
 trap 'rm -r "$dir"' EXIT
 cabal v2-haddock --builddir="$dir" --haddock-for-hackage --enable-doc
-cabal upload -d --publish $dir/*-docs.tar.gz
+cabal upload -d --publish "$dir"/*-docs.tar.gz
 
 # docker
 export VERSION=0.10
-docker build -t ldap-scim-bridge:${VERSION} .
-docker tag ldap-scim-bridge:${VERSION} quay.io/wire/ldap-scim-bridge:${VERSION}
+docker build -t ldap-scim-bridge:"${VERSION}" .
+docker tag ldap-scim-bridge:"${VERSION}" quay.io/wire/ldap-scim-bridge:"${VERSION}"
 docker login quay.io
-docker push quay.io/wire/ldap-scim-bridge:${VERSION}
+docker push quay.io/wire/ldap-scim-bridge:"${VERSION}"

--- a/examples/wire-server/run.sh
+++ b/examples/wire-server/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # put this to work with https://github.com/wireapp/wire-server
 #
@@ -65,8 +65,12 @@ function scaffolding2() {
 function scaffolding_spar() {
   if ( curl -s $BRIG_URL/i/status ); then
     WIRE_USER=$("${WIRE_SERVER_PATH}"/hack/bin/create_test_team_admins.sh -c)
-    WIRE_USERID=$(echo "$WIRE_USER" | sed 's/^\([^,]\+\),\([^,]\+\),\([^,]\+\)$/\1/')
-    WIRE_PASSWD=$(echo "$WIRE_USER" | sed 's/^\([^,]\+\),\([^,]\+\),\([^,]\+\)$/\3/')
+    # shellcheck disable=SC2001
+    # (style): See if you can use ${variable//search/replace} instead.
+    WIRE_USERID=$(echo "$WIRE_USER" | sed 's/^\([^,]\+\),\([^,]\+\),\([^,]\+\)$/\1/') 
+    # shellcheck disable=SC2001
+    # (style): See if you can use ${variable//search/replace} instead.
+    WIRE_PASSWD=$(echo "$WIRE_USER" | sed 's/^\([^,]\+\),\([^,]\+\),\([^,]\+\)$/\3/') 
     WIRE_TEAMID=$(curl -s -H'content-type: application/json' -H'Z-User: '"${WIRE_USERID}" "$BRIG_URL/self" | jq .team | xargs echo)
 
     # create a saml idp (if we don't, users will not be created, but invited, which would make the following more awkward to write down).

--- a/maintainer/release.sh
+++ b/maintainer/release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -x
 set -eo pipefail


### PR DESCRIPTION
Makes `treefmt .` happy :smile_cat: 