### PR TITLE
Add BOM creation and pushing via the tom-bombadil flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,40 @@ jobs:
         env:
           GHC_VERSION: ${{ matrix.ghc }}
 
+  bill-of-materials:
+    name: Build and push BOM file
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v27
+
+      - name: Set tag output
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/v}" >> $GITHUB_OUTPUT
+      - name: Check tag
+        run: echo ${TAG}
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+
+      - name: Build BOM dependencies
+        run: nix build .\#bomDependencies
+
+      - name: Build BOM file
+        run: nix run 'github:wireapp/tom-bombadil#create-sbom' -- --root-package-name "ldap-scim-bridge"
+
+      - name: Push BOM file
+        run: >-
+          nix run 'github:wireapp/tom-bombadil#upload-bom' --
+          --project-name "ldap-scim-bridge" 
+          --project-version "$TAG" 
+          --auto-create 
+          --bom-file ./sbom.json
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+          DEPENDENCY_TRACK_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+
   publish:
     name: Build and push docker image
     # needs : build

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ TAGS
 .direnv
 # default nix build output (symlink)
 result
+
+# SBOM file - https://github.com/wireapp/tom-bombadil
+sbom.json

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1737404927,
@@ -33,10 +51,26 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1738172511,
+        "narHash": "sha256-v/8yB8LIy/KsySZYN6rO/f4kCEkj+fTLkzR0TaNMB+w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "762a398892576efcc76fb233befbd58c2cef59e0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "tom-bombadil": "tom-bombadil"
       }
     },
     "systems": {
@@ -51,6 +85,41 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tom-bombadil": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1738738687,
+        "narHash": "sha256-iGKP+2je0CohjnkzUuqhOVPtQ/hphG63G3rygDl4z50=",
+        "owner": "wireapp",
+        "repo": "tom-bombadil",
+        "rev": "b85d21b8340db6954bfb4cb7c78e00e4d608afad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wireapp",
+        "ref": "sventennie/import-bombon",
+        "repo": "tom-bombadil",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,14 @@
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
+    tom-bombadil.url = "github:wireapp/tom-bombadil";
   };
 
   outputs =
     { self
     , nixpkgs
     , flake-utils
+    , tom-bombadil
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -93,9 +95,14 @@
             };
           })
           ghcVersions);
+
+        bomDependencies = tom-bombadil.lib.${system}.bomDependenciesDrv pkgs [ haskellPackages.ldap-scim-bridge ] haskellPackages;
       in
       {
-        packages.default = haskellPackages.ldap-scim-bridge;
+        packages = {
+          default = haskellPackages.ldap-scim-bridge;
+          bomDependencies = bomDependencies;
+        };
 
         # Development shell with required dependencies
         devShells = {


### PR DESCRIPTION
The benefit is that we now got one standardized way to do that.

I started this CI pipeline to test this by doing a fake-release: https://github.com/wireapp/ldap-scim-bridge/actions/runs/13243263951

The flake: https://github.com/wireapp/tom-bombadil

Ticket: https://wearezeta.atlassian.net/browse/WPB-15645